### PR TITLE
ServerHelperClient does not require authentication

### DIFF
--- a/src/main/java/com/genexus/gxserver/client/clients/BaseClient.java
+++ b/src/main/java/com/genexus/gxserver/client/clients/BaseClient.java
@@ -47,9 +47,15 @@ public abstract class BaseClient {
     }
 
     protected final ServiceData serviceData;
+    protected final boolean useNotSecure;
 
     BaseClient(ServiceData data) {
-        serviceData = data;
+        this(data, /* useNotSecure = */ false);
+    }
+
+    BaseClient(ServiceData data, boolean preferSecure) {
+        this.serviceData = data;
+        this.useNotSecure = preferSecure;
     }
 
     protected abstract ServiceInfo getServiceInfo();
@@ -71,6 +77,12 @@ public abstract class BaseClient {
 
     private BindingData getBindingData(ServiceData serviceData) throws MalformedURLException {
         BindingData binding = new BindingData();
+        
+        if (useNotSecure) {
+            binding.url = getNonSecureServiceURL(serviceData.getServerURL());
+            binding.isSecure = false;
+            return binding;
+        }
 
         URL secureURL = getSecureServiceURL(serviceData.getServerURL());
         binding.url = secureURL;

--- a/src/main/java/com/genexus/gxserver/client/clients/BaseClient.java
+++ b/src/main/java/com/genexus/gxserver/client/clients/BaseClient.java
@@ -53,9 +53,9 @@ public abstract class BaseClient {
         this(data, /* useNotSecure = */ false);
     }
 
-    BaseClient(ServiceData data, boolean preferSecure) {
+    BaseClient(ServiceData data, boolean useNotSecure) {
         this.serviceData = data;
-        this.useNotSecure = preferSecure;
+        this.useNotSecure = useNotSecure;
     }
 
     protected abstract ServiceInfo getServiceInfo();

--- a/src/main/java/com/genexus/gxserver/client/clients/ServerHelperClient.java
+++ b/src/main/java/com/genexus/gxserver/client/clients/ServerHelperClient.java
@@ -62,8 +62,8 @@ public class ServerHelperClient extends BaseClient {
         return SERVER_HELPER_INFO;
     }
 
-    public ServerHelperClient(String serverURL, String user, String password) throws MalformedURLException {
-        this(new ServiceData(serverURL, user, password));
+    public ServerHelperClient(String serverURL) throws MalformedURLException {
+        this(new ServiceData(serverURL, "", ""));
     }
 
     public ServerHelperClient(ServiceData serviceData) throws MalformedURLException {

--- a/src/main/java/com/genexus/gxserver/client/clients/ServerHelperClient.java
+++ b/src/main/java/com/genexus/gxserver/client/clients/ServerHelperClient.java
@@ -67,7 +67,7 @@ public class ServerHelperClient extends BaseClient {
     }
 
     public ServerHelperClient(ServiceData serviceData) throws MalformedURLException {
-        super(serviceData);
+        super(serviceData, /* useNotSecure = */ true);
     }
 
     private LocalContextServiceWrapper serverHelper = null;

--- a/src/test/java/com/genexus/gxserver/client/clients/ServerHelperClientTest.java
+++ b/src/test/java/com/genexus/gxserver/client/clients/ServerHelperClientTest.java
@@ -68,8 +68,9 @@ public class ServerHelperClientTest {
         ServiceData serverData = ServerData.getServerData();
         ServerHelperClient instance = new ServerHelperClient(
                 serverData.getServerURL().toString(),
-                serverData.getUserName(),
-                serverData.getUserPassword()
+                // no user info because this service should not require authentication
+                "",
+                ""
         );
 
         assertEquals(true, instance.isServerAlive());
@@ -86,8 +87,9 @@ public class ServerHelperClientTest {
         ServiceData serverData = ServerData.getServerData();
         ServerHelperClient instance = new ServerHelperClient(
                 serverData.getServerURL().toString(),
-                serverData.getUserName(),
-                serverData.getUserPassword()
+                // no user info because this service should not require authentication
+                "",
+                ""
         );
         
         ServerInfo info = instance.getServerInfo();

--- a/src/test/java/com/genexus/gxserver/client/clients/ServerHelperClientTest.java
+++ b/src/test/java/com/genexus/gxserver/client/clients/ServerHelperClientTest.java
@@ -67,10 +67,7 @@ public class ServerHelperClientTest {
 
         ServiceData serverData = ServerData.getServerData();
         ServerHelperClient instance = new ServerHelperClient(
-                serverData.getServerURL().toString(),
-                // no user info because this service should not require authentication
-                "",
-                ""
+                serverData.getServerURL().toString()
         );
 
         assertEquals(true, instance.isServerAlive());
@@ -86,10 +83,7 @@ public class ServerHelperClientTest {
 
         ServiceData serverData = ServerData.getServerData();
         ServerHelperClient instance = new ServerHelperClient(
-                serverData.getServerURL().toString(),
-                // no user info because this service should not require authentication
-                "",
-                ""
+                serverData.getServerURL().toString()
         );
         
         ServerInfo info = instance.getServerInfo();


### PR DESCRIPTION
- BaseClient supports forcing the use of non secure binding.
- ServerHelperClient declares using non secure binding
- ServerHelperClientTest uses empty credentials to make sure authentication is not required.