### PR TITLE
Fix file handle leaks on XmlHelper

### DIFF
--- a/src/main/java/com/genexus/gxserver/client/helpers/XmlHelper.java
+++ b/src/main/java/com/genexus/gxserver/client/helpers/XmlHelper.java
@@ -24,8 +24,13 @@
 package com.genexus.gxserver.client.helpers;
 
 import com.genexus.gxserver.client.clients.common.WithLocalContextClassLoader;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -36,10 +41,6 @@ import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
-import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.JAXBException;
-import jakarta.xml.bind.Marshaller;
-import jakarta.xml.bind.Unmarshaller;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
@@ -62,14 +63,21 @@ import org.xml.sax.SAXException;
  */
 public class XmlHelper {
 
-    public static <T> T parse(InputStream stream, Class<T> tClass) throws IOException, ParserConfigurationException, SAXException, JAXBException {
-        Reader reader = new InputStreamReader(stream, StandardCharsets.UTF_8.name());
-        InputSource source = new InputSource(reader);
-
-        return XmlHelper.parse(source, tClass);
+    public static <T> T parse(File file, Class<T> tClass) throws FileNotFoundException, IOException, ParserConfigurationException, SAXException, JAXBException {
+        try (FileInputStream fileStream = new FileInputStream(file)) {
+            return parse(fileStream, tClass);
+        }
     }
 
-    public static <T> T parse(InputSource source, Class<T> tClass) throws IOException, ParserConfigurationException, SAXException, JAXBException {
+    public static <T> T parse(InputStream stream, Class<T> tClass) throws IOException, ParserConfigurationException, SAXException, JAXBException {
+        try (Reader reader = new InputStreamReader(stream, StandardCharsets.UTF_8.name())) {
+            InputSource source = new InputSource(reader);
+
+            return XmlHelper.parse(source, tClass);
+        }
+    }
+
+    private static <T> T parse(InputSource source, Class<T> tClass) throws IOException, ParserConfigurationException, SAXException, JAXBException {
         DocumentBuilder builder = DocumentBuilders.createSaferDocumentBuilder(factory -> {
             factory.setNamespaceAware(true);
         });
@@ -109,9 +117,11 @@ public class XmlHelper {
     }
 
     public static <T> void writeXml(T instance, File file) throws FileNotFoundException, IOException, JAXBException {
-        FileOutputStream outputStream = new FileOutputStream(file);
-        OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8.name());
-        writeXml(instance, writer);
+        try (
+                FileOutputStream outputStream = new FileOutputStream(file);
+                OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8.name())) {
+            writeXml(instance, writer);
+        }
     }
 
     public static <T> void writeXml(T instance, Writer writer) throws JAXBException {
@@ -119,7 +129,7 @@ public class XmlHelper {
         jaxbMarshaller.marshal(instance, writer);
     }
 
-    public static <T> Marshaller createMarshaller(T instance) throws JAXBException {
+    private static <T> Marshaller createMarshaller(T instance) throws JAXBException {
         JAXBContext jaxbContext = JAXBContext.newInstance(instance.getClass());
         Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
         jaxbMarshaller.setProperty(Marshaller.JAXB_ENCODING, StandardCharsets.UTF_8.name());
@@ -157,7 +167,7 @@ public class XmlHelper {
         return sw.toString();
     }
 
-    public static void trimWhitespace(Node node) {
+    private static void trimWhitespace(Node node) {
         NodeList children = node.getChildNodes();
         for (int i = 0; i < children.getLength(); ++i) {
             Node child = children.item(i);

--- a/src/test/java/com/genexus/gxserver/client/helpers/XmlHelperTest.java
+++ b/src/test/java/com/genexus/gxserver/client/helpers/XmlHelperTest.java
@@ -1,0 +1,115 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2022 GeneXus S.A..
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.genexus.gxserver.client.helpers;
+
+import com.genexus.gxserver.client.info.RevisionList;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+/**
+ *
+ * @author jlr
+ */
+public class XmlHelperTest {
+
+    public XmlHelperTest() {
+    }
+
+    /**
+     * Test of parse method, of class XmlHelper.
+     */
+    @Test
+    public void testWriteAndParse() throws Exception {
+        System.out.println("parse");
+
+        RevisionList someObject = new RevisionList();
+
+        Path tempPath1 = Files.createTempFile("", ".tmp");
+        Path tempPath2 = Files.createTempFile("", ".tmp");
+        assertNotEquals(tempPath1, tempPath2);
+
+        File tempFile1 = tempPath1.toFile();
+        File tempFile2 = tempPath2.toFile();
+        assertEquals(tempPath1, tempFile1.toPath());
+        assertEquals(tempPath2, tempFile2.toPath());
+
+        // write to file 1
+        XmlHelper.writeXml(someObject, tempFile1);
+
+        // delete file1
+        // which also makes sure the file was properly closed after writing to it
+        Files.delete(tempPath1);
+
+        // write to file 2 and parse from it
+        XmlHelper.writeXml(someObject, tempFile2);
+        RevisionList parsedObject = XmlHelper.parse(tempFile2, someObject.getClass());
+
+        // make sure it was properly parsed
+        assertEquals(someObject, parsedObject);
+
+        // delete file1
+        // which also makes sure the file was properly closed after writing to
+        // and reading from it
+        Files.delete(tempPath2);
+    }
+
+    /**
+     * Test of normalizeXmlString method, of class XmlHelper.
+     */
+    @Test
+    public void testNormalizeXmlString() throws Exception {
+        System.out.println("normalizeXmlString");
+
+        String header = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
+
+        String inputString1 = "<root>  <node>  </node>  <node att1=\"att\">\r\n"
+                + "</node>\r\n"
+                + "       <node att1= \"att\" >\r\n"
+                + "</node> <node>      <subnode> </subnode>\r\n"
+                + "</node></root>";
+
+        String expResult = header
+                + "<root>\r\n"
+                + "  <node/>\r\n"
+                + "  <node att1=\"att\"/>\r\n"
+                + "  <node att1=\"att\"/>\r\n"
+                + "  <node>\r\n"
+                + "    <subnode/>\r\n"
+                + "  </node>\r\n"
+                + "</root>\r\n";
+        String result = XmlHelper.normalizeXmlString(inputString1);
+        assertEquals(expResult, result);
+
+        String inputString2 = header + inputString1;
+        result = XmlHelper.normalizeXmlString(inputString2);
+        assertEquals(expResult, result);
+
+        String inputString3 = header + "\r\n" + inputString1;
+        result = XmlHelper.normalizeXmlString(inputString3);
+        assertEquals(expResult, result);
+    }
+}


### PR DESCRIPTION
- Added parse(File file, ...)
- Make parse(InputStream stream, ...) close Reader and InputSource
- Make parse(InputSource source, ...) private
- Make writeXml() close FileOutputStream and OutputStreamWriter
- Make createMarshaller() private
- Make trimWhitespace() private

- Added tests for proper xml normalization and file handle releasing.